### PR TITLE
Feat/run by config

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,13 +205,12 @@ host: 0.0.0.0
 models:
   # Main model - loaded immediately when server starts
   qwen3-30b:
-    model: qwen3-30b-a3b-instruct-2507 
+    model: qwen3-30b-a3b-instruct-2507 # Featured model name from eternal-zoo
     on_demand: False  # Main model - loaded immediately
 
-  # On-demand models - loaded only when requested
-  flux-dev:
-    hash: bafkreiaha3sjfmv4affmi5kbu6bnayenf2avwafp3cthhar3latmfi632u
-    on_demand: True   # On-demand model - loaded when requested
+  flux-dev-nsfw:
+    model: flux-dev-nsfw # Featured model name from eternal-zoo
+    on_demand: True   # On-demand model - loaded only when requested
   
   # Hugging Face model
   medgemma-27b:
@@ -234,11 +233,13 @@ models:
 | Option | Description | Required | Default |
 |--------|-------------|----------|---------|
 | `on_demand` | `False` for main model, `True` for on-demand models | ✅ | `True` |
-| `model` | Featured model name from Eternal Zoo | ❌ | - |
-| `hash` | Filecoin hash for IPFS models | ❌ | - |
+| `model` | Featured model name from eternal-zoo or model name from Hugging Face | ❌ | - |
 | `hf_repo` | Hugging Face repository | ❌ | - |
 | `task` | Model task type (`chat`, `embed`, `image-generation`) | ❌ | `chat` |
 | `mmproj` | Multimodal projector file (for vision models) | ❌ | - |
+| `architecture` | Model architecture (for image-generation models) | ❌ | - |
+| `lora` | LoRA model (for LoRA models) | ❌ | - |
+| `base_model` | Base model name (for LoRA models) | ❌ | - |
 
 #### **Running with Config Files**
 

--- a/README.md
+++ b/README.md
@@ -230,16 +230,16 @@ models:
 
 #### **Model Configuration Options**
 
-| Option | Description | Required | Default |
-|--------|-------------|----------|---------|
-| `on_demand` | `False` for main model, `True` for on-demand models | ✅ | `True` |
-| `model` | Featured model name from eternal-zoo or model name from Hugging Face | ❌ | - |
-| `hf_repo` | Hugging Face repository | ❌ | - |
-| `task` | Model task type (`chat`, `embed`, `image-generation`) | ❌ | `chat` |
-| `mmproj` | Multimodal projector file (for vision models) | ❌ | - |
-| `architecture` | Model architecture (for image-generation models) | ❌ | - |
-| `lora` | LoRA model (for LoRA models) | ❌ | - |
-| `base_model` | Base model name (for LoRA models) | ❌ | - |
+| Option | Description | Default |
+|--------|-------------|---------|
+| `model` | Featured model name from eternal-zoo or model name from Hugging Face | - |
+| `hf_repo` | Hugging Face repository | - |
+| `task` | Model task type (`chat`, `embed`, `image-generation`) | `chat` |
+| `mmproj` | Multimodal projector file (for vision models) | - |
+| `architecture` | Model architecture (for image-generation models) | - |
+| `lora` | LoRA model (for LoRA models) | - |
+| `base_model` | Base model name (for LoRA models) | - |
+| `on_demand` | `False` for main model, `True` for on-demand models | `True` |
 
 #### **Running with Config Files**
 

--- a/eternal_zoo/cli.py
+++ b/eternal_zoo/cli.py
@@ -520,8 +520,8 @@ def handle_run(args):
                     
                     is_lora = hf_data.get("lora", False)
                     task = hf_data.get("task", "chat")
-                    if task == "image-generation":
-                        if is_lora:
+                    if is_lora:
+                        if task == "image-generation":
                             metadata_path = os.path.join(local_path, "metadata.json")
                             if not os.path.exists(metadata_path):
                                 print_error("LoRA model found but metadata.json is missing")
@@ -547,25 +547,25 @@ def handle_run(args):
                                     "path": os.path.join(local_path, lora_path),
                                     "scale": lora_scales[i]
                                 }
-                    else:
-                        print_warning(f"Task {task} not supported for {featured_model_name}")
-                        continue
-                    
-                    config_dict = {
-                        "model_id": model_name,
-                        "model": local_path,
-                        "context_length": DEFAULT_CONFIG.model.DEFAULT_CONTEXT_LENGTH,
-                        "model_name": featured_model_name,
-                        "task": task,
-                        "on_demand": not is_main,
-                        "is_lora": is_lora,
-                        "projector": projector_path,
-                        "multimodal": bool(projector_path),
-                        "architecture": model_config.get("architecture", None),
-                        "lora_config": lora_config,
-                    }
-                    configs.append(config_dict)
-                    continue
+                        else:
+                            print_warning(f"Lora model found but task {task} is not supported for lora")
+                            continue
+                        
+                config_dict = {
+                    "model_id": model_name,
+                    "model": local_path,
+                    "context_length": DEFAULT_CONFIG.model.DEFAULT_CONTEXT_LENGTH,
+                    "model_name": featured_model_name,
+                    "task": task,
+                    "on_demand": not is_main,
+                    "is_lora": is_lora,
+                    "projector": projector_path,
+                    "multimodal": bool(projector_path),
+                    "architecture": model_config.get("architecture", None),
+                    "lora_config": lora_config,
+                }
+                configs.append(config_dict)
+                continue
 
             if "hf_repo" in model_config:
                 # Download from Hugging Face
@@ -600,6 +600,7 @@ def handle_run(args):
                     "lora_config": None,
                 }                
                 configs.append(config_dict)
+
         
         if not configs:
             print_error("No valid models found in config file")

--- a/eternal_zoo/cli.py
+++ b/eternal_zoo/cli.py
@@ -532,6 +532,8 @@ def handle_run(args):
                             if base_model not in FEATURED_MODELS:
                                 print_error(f"Base model {base_model} not found in FEATURED_MODELS")
                                 sys.exit(1)
+                            if base_model in HASH_TO_MODEL:
+                                base_model = HASH_TO_MODEL[base_model]
                             base_model_hf_data = FEATURED_MODELS[base_model]
                             success, base_model_local_path = asyncio.run(download_model_async(base_model_hf_data, base_model))
                             if not success:

--- a/eternal_zoo/cli.py
+++ b/eternal_zoo/cli.py
@@ -531,9 +531,6 @@ def handle_run(args):
                             base_model = lora_metadata.get("base_model")
                             if base_model in HASH_TO_MODEL:
                                 base_model = HASH_TO_MODEL[base_model]
-                            if base_model not in FEATURED_MODELS:
-                                print_error(f"Base model {base_model} not found in FEATURED_MODELS")
-                                sys.exit(1)
                             base_model_hf_data = FEATURED_MODELS[base_model]
                             success, base_model_local_path = asyncio.run(download_model_async(base_model_hf_data, base_model))
                             if not success:

--- a/eternal_zoo/cli.py
+++ b/eternal_zoo/cli.py
@@ -530,9 +530,10 @@ def handle_run(args):
                                 lora_metadata = json.load(f)
                             base_model = lora_metadata.get("base_model")
                             if base_model in HASH_TO_MODEL:
+                                base_model_hash = base_model
                                 base_model = HASH_TO_MODEL[base_model]
                             base_model_hf_data = FEATURED_MODELS[base_model]
-                            success, base_model_local_path = asyncio.run(download_model_async(base_model_hf_data, base_model))
+                            success, base_model_local_path = asyncio.run(download_model_async(base_model_hf_data, base_model_hash))
                             if not success:
                                 print_error(f"Failed to download base model {base_model}")
                                 sys.exit(1)

--- a/eternal_zoo/cli.py
+++ b/eternal_zoo/cli.py
@@ -529,11 +529,11 @@ def handle_run(args):
                             with open(metadata_path, "r") as f:
                                 lora_metadata = json.load(f)
                             base_model = lora_metadata.get("base_model")
+                            if base_model in HASH_TO_MODEL:
+                                base_model = HASH_TO_MODEL[base_model]
                             if base_model not in FEATURED_MODELS:
                                 print_error(f"Base model {base_model} not found in FEATURED_MODELS")
                                 sys.exit(1)
-                            if base_model in HASH_TO_MODEL:
-                                base_model = HASH_TO_MODEL[base_model]
                             base_model_hf_data = FEATURED_MODELS[base_model]
                             success, base_model_local_path = asyncio.run(download_model_async(base_model_hf_data, base_model))
                             if not success:

--- a/eternal_zoo/cli.py
+++ b/eternal_zoo/cli.py
@@ -514,6 +514,8 @@ def handle_run(args):
                 if not success:
                     print_error(f"Failed to load metadata for {model_name}")
                     continue
+
+                config_dict["model_id"] = model_name
                     
             elif "hf_repo" in model_config:
                 # Download from Hugging Face
@@ -541,9 +543,11 @@ def handle_run(args):
                     "model_name": model_id,
                     "task": model_config.get("task", "chat"),
                     "on_demand": not is_main,
-                    "is_lora": False,
+                    "is_lora": model_config.get("lora", False),
                     "projector": projector_path,
                     "multimodal": bool(projector_path),
+                    "architecture": model_config.get("architecture", None),
+                    "lora_config": model_config.get("lora_config", None),
                 }
                 
             elif "model" in model_config:
@@ -559,11 +563,24 @@ def handle_run(args):
                 if not success:
                     print_error(f"Failed to download model {model_name}")
                     continue
-                    
-                success, config_dict = load_model_metadata(model_hash or featured_model_name, is_main=is_main)
-                if not success:
-                    print_error(f"Failed to load metadata for {model_name}")
-                    continue
+
+                projector_path = None
+                if os.path.exists(local_path + "-projector"):
+                    projector_path = local_path + "-projector"
+
+                config_dict = {
+                    "task": model_config.get("task", "chat"),
+                    "model_id": model_name,
+                    "model": local_path,
+                    "context_length": DEFAULT_CONFIG.model.DEFAULT_CONTEXT_LENGTH,
+                    "model_name": featured_model_name,
+                    "on_demand": not is_main,
+                    "is_lora": model_config.get("lora", False),
+                    "projector": projector_path,
+                    "multimodal": bool(projector_path),
+                    "architecture": model_config.get("architecture", None),
+                    "lora_config": model_config.get("lora_config", None),
+                }
             else:
                 print_error(f"Invalid model configuration for {model_name}: must specify 'hash', 'hf_repo', or 'model'")
                 continue

--- a/eternal_zoo/cli.py
+++ b/eternal_zoo/cli.py
@@ -551,22 +551,22 @@ def handle_run(args):
                             print_warning(f"Lora model found but task {task} is not supported for lora")
                             continue
                         
-                config_dict = {
-                    "model_id": model_name,
-                    "model": local_path,
-                    "context_length": DEFAULT_CONFIG.model.DEFAULT_CONTEXT_LENGTH,
-                    "model_name": featured_model_name,
-                    "task": task,
-                    "on_demand": not is_main,
-                    "is_lora": is_lora,
-                    "projector": projector_path,
-                    "multimodal": bool(projector_path),
-                    "architecture": model_config.get("architecture", None),
-                    "lora_config": lora_config,
-                }
-                configs.append(config_dict)
-                continue
-
+                    config_dict = {
+                        "model_id": model_name,
+                        "model": local_path,
+                        "context_length": DEFAULT_CONFIG.model.DEFAULT_CONTEXT_LENGTH,
+                        "model_name": featured_model_name,
+                        "task": task,
+                        "on_demand": not is_main,
+                        "is_lora": is_lora,
+                        "projector": projector_path,
+                        "multimodal": bool(projector_path),
+                        "architecture": hf_data.get("architecture", None),
+                        "lora_config": lora_config,
+                    }
+                    configs.append(config_dict)
+                    continue
+                
             if "hf_repo" in model_config:
                 # Download from Hugging Face
                 hf_data = {

--- a/eternal_zoo/cli.py
+++ b/eternal_zoo/cli.py
@@ -2,8 +2,9 @@ import sys
 import os
 import asyncio
 import argparse
-import random
 import json
+import yaml
+import random
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
@@ -127,7 +128,12 @@ def parse_args():
         help="🚀 Launch AI model server with multi-model support",
         description="Start serving models locally with multi-model and on-demand loading support"
     )
-
+    run_command.add_argument(
+        "--config",
+        type=str,
+        help="🔍 Config file path",
+        metavar="CONFIG"
+    )
     run_command.add_argument(
         "model_name",
         nargs='?',
@@ -201,6 +207,7 @@ def parse_args():
     )
     serve_command.add_argument(
         "--main-hash",
+        type=str,
         help="🔗 Hash of the main model to serve (if not specified, uses random model)",
         metavar="HASH"
     )
@@ -406,7 +413,26 @@ def parse_args():
 
 def handle_download(args) -> bool:
     """Handle model download with beautiful output"""
-    # Determine the download source and validate inputs
+    main_model_id = None
+    # run by config file with multi-model support
+    if args.config:
+        # read config file from yaml
+        with open(args.config, "r") as f:
+            config = yaml.safe_load(f)
+        port = config.get("port", 8080)
+        host = config.get("host", "0.0.0.0")
+        models = config.get("models", {})
+        main_model_id = None
+        for model_name, model_config in models.items():
+            on_demand = model_config.get("on_demand", False)
+            if not on_demand:
+                main_model_id = model_name
+                break
+        if not main_model_id:
+            print_warning("No active model found in config file, using random model")
+            main_model_id = random.choice(list(models.keys()))
+
+    
     if args.hash:
         # Download by hash
         if args.hash not in HASH_TO_MODEL:
@@ -442,6 +468,121 @@ def handle_download(args) -> bool:
 
 def handle_run(args):
     """Handle model loading and configuration based on provided arguments."""
+    # Handle config file case with multi-model support
+    if args.config:
+        # read config file from yaml
+        with open(args.config, "r") as f:
+            config = yaml.safe_load(f)
+        port = config.get("port", 8080)
+        host = config.get("host", "0.0.0.0")
+        models = config.get("models", {})
+        
+        # Build configurations for all models
+        configs = []
+        main_model_id = None
+        
+        # First pass: find the main model (on_demand=False)
+        for model_name, model_config in models.items():
+            on_demand = model_config.get("on_demand", False)
+            if not on_demand:
+                main_model_id = model_name
+                break
+        
+        if not main_model_id:
+            print_warning("No main model found in config file (on_demand=False), using first model")
+            main_model_id = list(models.keys())[0]
+        
+        # Second pass: create configurations for all models
+        for model_name, model_config in models.items():
+            is_main = (model_name == main_model_id)
+            
+            # Handle different model sources
+            if "hash" in model_config:
+                # Download by Filecoin hash
+                model_hash = model_config["hash"]
+                if model_hash not in HASH_TO_MODEL:
+                    print_error(f"Hash {model_hash} not found in HASH_TO_MODEL")
+                    continue
+                featured_model_name = HASH_TO_MODEL[model_hash]
+                hf_data = FEATURED_MODELS[featured_model_name]
+                success, local_path = asyncio.run(download_model_async(hf_data, model_hash))
+                if not success:
+                    print_error(f"Failed to download model {model_name}")
+                    continue
+                    
+                success, config_dict = load_model_metadata(model_hash, is_main=is_main)
+                if not success:
+                    print_error(f"Failed to load metadata for {model_name}")
+                    continue
+                    
+            elif "hf_repo" in model_config:
+                # Download from Hugging Face
+                hf_data = {
+                    "repo": model_config["hf_repo"],
+                    "model": model_config["model"],
+                    "projector": model_config.get("mmproj"),
+                }
+                success, local_path = asyncio.run(download_model_async(hf_data))
+                if not success:
+                    print_error(f"Failed to download model {model_name}")
+                    continue
+                    
+                model_id = os.path.basename(local_path)
+                projector_path = None
+                if model_config.get("mmproj"):
+                    mmproj_path = local_path + "-projector"
+                    if os.path.exists(mmproj_path):
+                        projector_path = mmproj_path
+                        
+                config_dict = {
+                    "model_id": model_id,
+                    "model": local_path,
+                    "context_length": DEFAULT_CONFIG.model.DEFAULT_CONTEXT_LENGTH,
+                    "model_name": model_id,
+                    "task": model_config.get("task", "chat"),
+                    "on_demand": not is_main,
+                    "is_lora": False,
+                    "projector": projector_path,
+                    "multimodal": bool(projector_path),
+                }
+                
+            elif "model" in model_config:
+                # Featured model by name
+                featured_model_name = model_config["model"]
+                if featured_model_name not in FEATURED_MODELS:
+                    print_error(f"Model {featured_model_name} not found in FEATURED_MODELS")
+                    continue
+                    
+                hf_data = FEATURED_MODELS[featured_model_name]
+                model_hash = MODEL_TO_HASH.get(featured_model_name)
+                success, local_path = asyncio.run(download_model_async(hf_data, model_hash))
+                if not success:
+                    print_error(f"Failed to download model {model_name}")
+                    continue
+                    
+                success, config_dict = load_model_metadata(model_hash or featured_model_name, is_main=is_main)
+                if not success:
+                    print_error(f"Failed to load metadata for {model_name}")
+                    continue
+            else:
+                print_error(f"Invalid model configuration for {model_name}: must specify 'hash', 'hf_repo', or 'model'")
+                continue
+                
+            configs.append(config_dict)
+        
+        if not configs:
+            print_error("No valid models found in config file")
+            sys.exit(1)
+            
+        # Start the multi-model server
+        success = manager.start(configs, port, host)
+        if not success:
+            print_error("Failed to start multi-model server")
+            sys.exit(1)
+            
+        print_success(f"Multi-model server started with {len(configs)} models")
+        return success
+    
     # Handle Hugging Face repository case separately
     if args.hf_repo:
         hf_data = {
@@ -641,68 +782,58 @@ def load_model_metadata(model_id, is_main=False) -> tuple[bool, dict | None]:
         is_main (bool): Whether this is the main model (default: False).
 
     Returns:
-        dict: Configuration dictionary for the model.
+        tuple[bool, dict | None]: Success status and configuration dictionary.
     """
-    json_path = os.path.join(DEFAULT_MODEL_DIR, f"{model_id}.json")
+    # Use pathlib for consistent path operations
+    model_dir = DEFAULT_MODEL_DIR
+    json_path = model_dir / f"{model_id}.json"
+    
+    # Load metadata with optimized error handling
     try:
-        with open(json_path, "r") as f:
+        with json_path.open("r") as f:
             metadata = json.load(f)
-    except FileNotFoundError:
+    except (FileNotFoundError, OSError):
         print_warning(f"Metadata file not found for model {model_id}")
         return False, None
-    except json.JSONDecodeError:
-        print_warning(f"Invalid JSON in metadata file for model {model_id}")
+    except json.JSONDecodeError as e:
+        print_warning(f"Invalid JSON in metadata file for model {model_id}: {e}")
         return False, None
 
-    local_path = os.path.join(DEFAULT_MODEL_DIR, model_id)
-    if not os.path.exists(local_path):
-        local_path = local_path + POSTFIX_MODEL_PATH
-        if not os.path.exists(local_path):
+    # Optimize path checking - check both paths at once
+    local_path = model_dir / model_id
+    if not local_path.exists():
+        local_path = model_dir / f"{model_id}{POSTFIX_MODEL_PATH}"
+        if not local_path.exists():
             print_warning(f"Model file not found for model {model_id}")
             return False, None
 
-    projector_path = None
-    if metadata.get("multimodal", False):
-        projector_path = os.path.join(DEFAULT_MODEL_DIR, f"{model_id}-projector")
+    # Extract metadata values once
+    is_multimodal = metadata.get("multimodal", False)
+    is_lora = metadata.get("lora", False)
+    model_name = metadata.get("model_name") or metadata.get("folder_name", model_id)
+    
+    # Handle projector path for multimodal models
+    projector_path = str(model_dir / f"{model_id}-projector") if is_multimodal else None
     
     lora_config = None
-    is_lora = metadata.get("lora", False)
-    model_name = metadata.get("model_name", None)
-    if model_name is None:
-        model_name = metadata.get("folder_name", model_id)
-
     if is_lora:
-        lora_config = {}
-        lora_metadata_path = os.path.join(local_path, "metadata.json")
-        if not os.path.exists(lora_metadata_path):
-            print_warning("LoRA model found but metadata.json is missing")
+        lora_config = _load_lora_config(local_path, model_dir)
+        if lora_config is None:
             return False, None
-        with open(lora_metadata_path, "r") as f:
-            lora_metadata = json.load(f)
-        lora_paths = lora_metadata["lora_paths"]
-        lora_scales = lora_metadata["lora_scales"]
-        for i, lora_path in enumerate(lora_paths):
-            lora_name = os.path.basename(lora_path)
-            lora_config[lora_name] = {
-                "path": os.path.join(local_path, lora_path),
-                "scale": lora_scales[i]
-            }
-        base_model_hash = lora_metadata["base_model"]
-        if base_model_hash not in HASH_TO_MODEL:
-            print_warning(f"Base model hash {base_model_hash} not found")
+        
+        # Handle base model for LoRA
+        base_model_result = _handle_lora_base_model(lora_config.pop("_metadata", {}))
+        if base_model_result is None:
             return False, None
-        base_model_name = HASH_TO_MODEL[base_model_hash]
-        base_model_hf_data = FEATURED_MODELS[base_model_name]
-        success, base_model_local_path = asyncio.run(download_model_async(base_model_hf_data, base_model_hash))
-        local_path = base_model_local_path
-        model_name = base_model_name
+        local_path, model_name = base_model_result
 
+    # Build configuration dictionary
     config = {
         "model_id": model_id,
         "model_name": model_name,
         "task": metadata.get("task", "chat"),
-        "model": local_path,
-        "multimodal": metadata.get("multimodal", False),
+        "model": str(local_path),
+        "multimodal": is_multimodal,
         "projector": projector_path,
         "on_demand": not is_main,
         "is_lora": is_lora,
@@ -712,6 +843,72 @@ def load_model_metadata(model_id, is_main=False) -> tuple[bool, dict | None]:
     }
     return True, config
 
+
+def _load_lora_config(local_path, model_dir):
+    """Helper function to load LoRA configuration."""
+    lora_metadata_path = local_path / "metadata.json"
+    if not lora_metadata_path.exists():
+        print_warning("LoRA model found but metadata.json is missing")
+        return None
+    
+    try:
+        with lora_metadata_path.open("r") as f:
+            lora_metadata = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print_warning(f"Failed to read LoRA metadata: {e}")
+        return None
+    
+    # Build LoRA configuration efficiently
+    lora_paths = lora_metadata.get("lora_paths", [])
+    lora_scales = lora_metadata.get("lora_scales", [])
+    
+    if len(lora_paths) != len(lora_scales):
+        print_warning("Mismatch between LoRA paths and scales")
+        return None
+    
+    lora_config = {
+        os.path.basename(lora_path): {
+            "path": str(local_path / lora_path),
+            "scale": lora_scales[i]
+        }
+        for i, lora_path in enumerate(lora_paths)
+    }
+    
+    # Store metadata for base model handling
+    lora_config["_metadata"] = lora_metadata
+    return lora_config
+
+
+def _handle_lora_base_model(lora_metadata):
+    """Helper function to handle LoRA base model resolution."""
+    base_model_hash = lora_metadata.get("base_model")
+    if not base_model_hash:
+        print_warning("LoRA metadata missing base_model hash")
+        return None
+        
+    if base_model_hash not in HASH_TO_MODEL:
+        print_warning(f"Base model hash {base_model_hash} not found")
+        return None
+    
+    base_model_name = HASH_TO_MODEL[base_model_hash]
+    if base_model_name not in FEATURED_MODELS:
+        print_warning(f"Base model {base_model_name} not in featured models")
+        return None
+        
+    base_model_hf_data = FEATURED_MODELS[base_model_name]
+    
+    try:
+        success, base_model_local_path = asyncio.run(
+            download_model_async(base_model_hf_data, base_model_hash)
+        )
+        if not success:
+            print_warning(f"Failed to download base model {base_model_name}")
+            return None
+        return base_model_local_path, base_model_name
+    except Exception as e:
+        print_warning(f"Error downloading base model: {e}")
+        return None
+
 def handle_serve(args):
     """Handle model serve command - run all downloaded models with specified main model.
 
@@ -719,7 +916,7 @@ def handle_serve(args):
         args: Command-line arguments containing host, port, main_hash, and main_model.
     """
     print_info("Discovering downloaded models in models directory...")
-
+            
     # Get all downloaded models
     downloaded_models = get_all_downloaded_models()
 

--- a/eternal_zoo/download.py
+++ b/eternal_zoo/download.py
@@ -479,8 +479,7 @@ async def download_model_from_hf(data: dict, final_dir: str | None = None) -> tu
                         if final_path:
                             await async_move(tmp_dir, final_path)
                             res["model_path"] = final_path
-                            return True, res
-                        
+                                                   
                     else:
                         command = f"hf download {repo_id} --local-dir {tmp_dir}"
                         await loop.run_in_executor(
@@ -495,7 +494,8 @@ async def download_model_from_hf(data: dict, final_dir: str | None = None) -> tu
                         if final_path:
                             await async_move(tmp_dir, final_path)
                             res["model_path"] = final_path
-                            return True, res
+                        
+                    return True, res
                 
                 skip_download_model = False
                 skip_download_projector = False

--- a/eternal_zoo/models.py
+++ b/eternal_zoo/models.py
@@ -155,24 +155,28 @@ FEATURED_MODELS = {
         "repo": "NikolaSigmoid/FLUX.1-dev-NSFW-Master",
         "task": "image-generation",
         "lora": True,
-        "base_model": "flux-dev"
+        "base_model": "flux-dev",
+        "architecture": "flux-dev"
     },
     "flux-dev-18-loras": {
         "repo": "NikolaSigmoid/FLUX.1-dev-18-loras",
         "task": "image-generation",
         "lora": True,
-        "base_model": "flux-dev"
+        "base_model": "flux-dev",
+        "architecture": "flux-dev"
     },
     "nsfw-lab": {
        "repo": "NikolaSigmoid/NSFW-Lab",
        "task": "image-generation",
        "lora": True,
-       "base_model": "flux-schnell"
+       "base_model": "flux-schnell",
+       "architecture": "flux-schnell"
     },
     "lora-lab": {
         "repo": "NikolaSigmoid/lora-lab",
         "task": "image-generation",
         "lora": True,
-        "base_model": "flux-dev"
+        "base_model": "flux-dev",
+        "architecture": "flux-dev"
     }
 }

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,27 +1,26 @@
 port: 8080
 host: 0.0.0.0
 models:
-  # from featured models
+  # Main model - loaded immediately when server starts
   qwen3-30b:
-    model: qwen3-30b-a3b-instruct-2507 
-    on_demand: False  # Main model - loaded immediately when server starts
+    model: qwen3-30b-a3b-instruct-2507 # Featured model name from eternal-zoo
+    on_demand: False  # Main model - loaded immediately
 
-  # from filecoin hash
-  flux-dev:
-    hash: bafkreiaha3sjfmv4affmi5kbu6bnayenf2avwafp3cthhar3latmfi632u
+  flux-dev-nsfw:
+    model: flux-dev-nsfw # Featured model name from eternal-zoo
     on_demand: True   # On-demand model - loaded only when requested
   
-  # from huggingface models
+  # Hugging Face model
   medgemma-27b:
-    hf_repo: unsloth/medgemma-27b-it-GGUF
+    hf_repo: medgemma/MedGemma-3-27B-GGUF
     model: medgemma-27b-it-Q8_0.gguf
     mmproj: mmproj-F16.gguf
     task: chat
-    on_demand: True   # On-demand model - loaded only when requested
+    on_demand: True   # On-demand model - loaded when requested
   
-  # from huggingface models
-  jina-embeddings-v4-text-code:
+  # Embedding model
+  jina-embeddings-v4:
     hf_repo: jinaai/jina-embeddings-v4-text-code-GGUF
     model: jina-embeddings-v4-text-code-F16.gguf
     task: embed
-    on_demand: True   # On-demand model - loaded only when requested
+    on_demand: True   # On-demand model - loaded when requested

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,27 @@
+port: 8080
+host: 0.0.0.0
+models:
+  # from featured models
+  qwen3-30b:
+    model: qwen3-30b-a3b-instruct-2507 
+    on_demand: False  # Main model - loaded immediately when server starts
+
+  # from filecoin hash
+  flux-dev:
+    hash: bafkreiaha3sjfmv4affmi5kbu6bnayenf2avwafp3cthhar3latmfi632u
+    on_demand: True   # On-demand model - loaded only when requested
+  
+  # from huggingface models
+  medgemma-27b:
+    hf_repo: medgemma/MedGemma-3-27B-GGUF
+    model: medgemma-27b-it-Q8_0.gguf
+    mmproj: mmproj-F16.gguf
+    task: chat
+    on_demand: True   # On-demand model - loaded only when requested
+  
+  # from huggingface models
+  jina-embeddings-v4:
+    hf_repo: jinaai/jina-embeddings-v4-text-code-GGUF
+    model: jina-embeddings-v4-text-code-F16.gguf
+    task: embed
+    on_demand: True   # On-demand model - loaded only when requested

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -13,14 +13,14 @@ models:
   
   # from huggingface models
   medgemma-27b:
-    hf_repo: medgemma/MedGemma-3-27B-GGUF
+    hf_repo: unsloth/medgemma-27b-it-GGUF
     model: medgemma-27b-it-Q8_0.gguf
     mmproj: mmproj-F16.gguf
     task: chat
     on_demand: True   # On-demand model - loaded only when requested
   
   # from huggingface models
-  jina-embeddings-v4:
+  jina-embeddings-v4-text-code:
     hf_repo: jinaai/jina-embeddings-v4-text-code-GGUF
     model: jina-embeddings-v4-text-code-F16.gguf
     task: embed


### PR DESCRIPTION
# 🚀 feat: Add config file support for multi-model serving

## **New Feature: `eai model run --config <config_path>`**

This PR introduces a powerful new way to serve multiple AI models using YAML configuration files, enabling flexible multi-model deployments with on-demand loading capabilities.

## �� **Key Features**

- **📋 Config-Driven Deployment**: Define multiple models in a single YAML file
- **⚡ On-Demand Loading**: Load models only when first requested (memory efficient)
- **🎯 Main Model Selection**: Automatically designate a primary model for immediate loading
- **🔄 Dynamic Model Switching**: Seamlessly switch between models via API requests
- **📦 Mixed Model Sources**: Support both **eternal-zoo featured models** and **Hugging Face repositories**

## �� **Usage**

```bash
# Run multiple models using config file
eai model run --config config.yaml
```

## 📋 **Config File Structure**

```yaml
port: 8080
host: 0.0.0.0
models:
  # Main model - loaded immediately when server starts
  qwen3-30b:
    model: qwen3-30b-a3b-instruct-2507
    on_demand: False  # Main model - loaded immediately

  # On-demand models - loaded only when requested
  flux-dev-nsfw:
    model: flux-dev-nsfw
    on_demand: True

  # Hugging Face models
  medgemma-27b:
    hf_repo: medgemma/MedGemma-3-27B-GGUF
    model: medgemma-27b-it-Q8_0.gguf
    mmproj: mmproj-F16.gguf
    task: chat
    on_demand: True

  # Embedding models
  jina-embeddings-v4:
    hf_repo: jinaai/jina-embeddings-v4-text-code-GGUF
    model: jina-embeddings-v4-text-code-F16.gguf
    task: embed
    on_demand: True
```

## 🎯 **Main Model Selection Logic**

- **Primary Rule**: First model with `on_demand: False` becomes the main model
- **Fallback**: If no model has `on_demand: False`, the first model becomes main
- **Behavior**: Main model loads immediately, on-demand models load when first requested

## 🔄 **Request-Based Model Switching**

When clients specify a model via the `model` field in API requests:

1. **Smart Validation**: Checks model ID format and task compatibility
2. **Stream Protection**: Waits for active streams to complete before switching
3. **Automatic Loading**: On-demand models load seamlessly when first requested
4. **Graceful Fallbacks**: Invalid requests default to main model without errors

## 📊 **Configuration Options**

| Option | Description | Default |
|--------|-------------|---------|
| `model` | Featured model name from eternal-zoo or model name from Hugging Face | - |
| `hf_repo` | Hugging Face repository | - |
| `task` | Model task type (`chat`, `embed`, `image-generation`) | `chat` |
| `mmproj` | Multimodal projector file (for vision models) | - |
| `architecture` | Model architecture (for image-generation models) | - |
| `lora` | LoRA model (for LoRA models) | - |
| `base_model` | Base model name (for LoRA models) | - |
| `on_demand` | `False` for main model, `True` for on-demand models | `True` |