### PR TITLE
Update/schema

### DIFF
--- a/eternal_zoo/schema.py
+++ b/eternal_zoo/schema.py
@@ -104,6 +104,7 @@ class ChatTemplateKwargs(BaseModel):
     Represents the arguments for a chat template.
     """
     enable_thinking: bool = Field(True, description="Whether to enable thinking mode")
+    reasoning_effort: Optional[Literal["low", "medium", "high"]] = Field("medium", description="The effort of the reasoning")
 
 # Common request base for both streaming and non-streaming
 class ChatCompletionRequestBase(BaseModel):

--- a/eternal_zoo/schema.py
+++ b/eternal_zoo/schema.py
@@ -113,7 +113,7 @@ class ChatCompletionRequestBase(BaseModel):
     model: str = Field(DEFAULT_CONFIG.model.DEFAULT_CHAT_MODEL, description="Model to use for completion")
     messages: List[Message] = Field(..., description="List of messages in the conversation")
     tools: Optional[List[Dict[str, Any]]] = Field(None, description="Available tools for the model")
-    tool_choice: Optional[Union[str, Dict[str, Any]]] = Field(None, description="Tool choice configuration")
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = Field("auto", description="Tool choice configuration")
     max_tokens: Optional[int] = Field(None, description="Maximum number of tokens to generate")
     seed: Optional[int] = Field(0, description="Random seed for generation")
     response_format: Optional[Dict[str, Any]] = Field(None, description="Format for the response")


### PR DESCRIPTION
# feat: enhance schema for OpenAI API standard compliance

- Add audio input support with `AudioInput` model and `MultimodalContentItem`
- Improve tool call models with optional fields and index support
- Add `reasoning_content` and `tool_call_id` to `Message` model
- Add `reasoning_effort` argument to `ChatTemplateKwargs` with low/medium/high options
- Set `tool_choice` default to `"auto"` for better API compatibility
- Reorganize schema with clear section headers for better maintainability
- Clean up field descriptions and remove trailing periods
- Add comprehensive image generation models with proper enums
- Enhance validation and error handling throughout schema