### PR TITLE
Fit/reasoning with tools

### DIFF
--- a/eternal_zoo/apis.py
+++ b/eternal_zoo/apis.py
@@ -196,8 +196,14 @@ class ServiceHandler:
         if reasoning_content:
             reasoning_content = "<think>\n\n" + reasoning_content + "</think>\n\n"
 
-        content = response_data.get("choices", [])[0].get("message", {}).get("content", "")
-        response_data["choices"][0]["message"]["content"] = (reasoning_content + content) if reasoning_content else content
+        final_content = None
+        content = response_data.get("choices", [])[0].get("message", {}).get("content", None)
+        if reasoning_content:
+            final_content = reasoning_content
+        if content:
+            final_content = final_content + content
+
+        response_data["choices"][0]["message"]["content"] = final_content
         response_data["choices"][0]["message"]["reasoning_content"] = reasoning_content
 
         return ChatCompletionResponse(


### PR DESCRIPTION
# Fix reasoning with tools for non-streaming requests

**Changes:**
- Fixed handling of `reasoning_content` in non-streaming API calls to properly handle null values
- Improved tool call processing in streaming responses to handle both content and tool_calls when exiting thinking mode
- Enhanced null checks for tool call properties (`id`, `name`, `arguments`)

**Files modified:**
- `eternal_zoo/apis.py` - Fixed reasoning content processing and tool call handling

The changes ensure proper handling of reasoning content when it's null and improve the transition from thinking mode to tool calls in streaming responses.