### PR TITLE
Fix/reasoning content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ download:
 
 # Package versions
 MLX_FLUX_TAG=1.0.5
-MLX_OPENAI_SERVER_TAG=1.2.11
+MLX_OPENAI_SERVER_TAG=1.2.12
 ETERNAL_ZOO_TAG=2.0.25
 
 # Default target

--- a/eternal_zoo/apis.py
+++ b/eternal_zoo/apis.py
@@ -204,7 +204,7 @@ class ServiceHandler:
             final_content = final_content + content
 
         response_data["choices"][0]["message"]["content"] = final_content
-        response_data["choices"][0]["message"]["reasoning_content"] = reasoning_content
+        response_data["choices"][0]["message"]["reasoning_content"] = None
 
         return ChatCompletionResponse(
             id=response_data.get("id", generate_chat_completion_id()),


### PR DESCRIPTION
## fix: Clean up reasoning_content in non-streaming responses

- Set `reasoning_content` to `None` in non-streaming chat completion responses
- Update MLX_OPENAI_SERVER to version 1.2.12

This ensures that `reasoning_content` is properly cleaned up in the response 
object, preventing it from being exposed to clients in non-streaming mode.