### PR TITLE
refactor: add safety check for choices array in API response handling

### DIFF
--- a/eternal_zoo/apis.py
+++ b/eternal_zoo/apis.py
@@ -192,22 +192,25 @@ class ServiceHandler:
         # Make a non-streaming API call
         logger.debug(f"Making non-streaming request for model {request.model}")
         response_data = await ServiceHandler._make_api_call(host, port, "/v1/chat/completions", request_dict)
-        reasoning_content = response_data.get("choices", [])[0].get("message", {}).get("reasoning_content", None)
-        if reasoning_content:
-            reasoning_content = "<think>\n\n" + reasoning_content + "</think>\n\n"
+        # reasoning_content = response_data.get("choices", [])[0].get("message", {}).get("reasoning_content", None)
+        choices = response_data.get("choices", [])
+        if len(choices) > 0:
+            reasoning_content = choices[0].get("message", {}).get("reasoning_content", None)
+            if reasoning_content:
+                reasoning_content = "<think>\n\n" + reasoning_content + "</think>\n\n"
 
-        final_content = None
-        content = response_data.get("choices", [])[0].get("message", {}).get("content", None)
-        if reasoning_content:
-            final_content = reasoning_content
-        if content:
-            if final_content:
-                final_content = final_content + content
-            else:
-                final_content = content
+            final_content = None
+            content = choices[0].get("message", {}).get("content", None)
+            if reasoning_content:
+                final_content = reasoning_content
+            if content:
+                if final_content:
+                    final_content = final_content + content
+                else:
+                    final_content = content
 
-        response_data["choices"][0]["message"]["content"] = final_content
-        response_data["choices"][0]["message"]["reasoning_content"] = None
+            response_data["choices"][0]["message"]["content"] = final_content
+            response_data["choices"][0]["message"]["reasoning_content"] = None
 
         return ChatCompletionResponse(
             id=response_data.get("id", generate_chat_completion_id()),


### PR DESCRIPTION
# Fix: Add safety check for choices array in non-streaming API response handling

This PR addresses a potential runtime error in the non-streaming chat completion endpoint where the code was accessing the `choices` array without proper bounds checking.

## 🐛 Problem

The original code in `eternal_zoo/apis.py` was directly accessing `response_data.get("choices", [])[0]` without verifying that the choices array actually contained elements. This could lead to an `IndexError` if the underlying AI service returned an empty choices array, which would cause the entire request to fail.

## ✅ Solution

Added a safety check to verify that the `choices` array has at least one element before attempting to access `choices[0]`. The fix:

1. **Extracts the choices array** into a variable first
2. **Checks array length** with `if len(choices) > 0:`
3. **Only processes the response** if there are actual choices available
4. **Maintains the same logic** for handling `reasoning_content` and `content` fields