### PR TITLE
Feat/hermes 4

### DIFF
--- a/eternal_zoo/manager.py
+++ b/eternal_zoo/manager.py
@@ -839,7 +839,7 @@ class EternalZooManager:
                 "--pooling", "mean",
                 "--no-webui",
                 "--no-context-shift",
-                "-fa",
+                "-fa", "on",
                 "-ngl", "9999",
                 "-c", str(context_length),
                 "--embeddings",
@@ -888,6 +888,7 @@ class EternalZooManager:
             self.llama_server_path,
             "--model", str(model_path),
             "--embedding",
+            "-fa", "on",
             "--pooling", "mean",
             "-ub", "4096",
             "-ngl", "9999"

--- a/eternal_zoo/models.py
+++ b/eternal_zoo/models.py
@@ -177,9 +177,15 @@ FEATURED_MODELS = {
         "task": "chat",
         "backend": "mlx-lm"
     },
+    "hermes-4-14b": {
+        "repo": "bartowski/NousResearch_Hermes-4-14B-GGUF",
+        "model": "NousResearch_Hermes-4-14B-Q4_K_M.gguf",
+        "task": "chat",
+        "backend": "gguf"
+    },
     "hermes-4-70b": {
         "repo": "bartowski/NousResearch_Hermes-4-70B-GGUF",
-        "model": "NousResearch_Hermes-4-70B-Q4_K_M.gguf",
+        "model": "NousResearch_Hermes-4-14B-Q8_0.gguf",
         "task": "chat",
         "backend": "gguf"
     },

--- a/eternal_zoo/models.py
+++ b/eternal_zoo/models.py
@@ -19,6 +19,7 @@ HASH_TO_MODEL = {
     "bafkreibokz6tdke7k3eozsro3hh3luyqbub7tzdawpswtt7q6bzfg36fw4": "dolphin-3.0-llama3.1-8b",
     "bafkreiclhnqcjfbbusqmg73jcwasomv7tqchkqm3fea5wwzs5vavc2wzfq": "gpt-oss-20b",
     "bafkreia4xtrb4vfsf7lblomjwh7cc3nlpci3fsqyeqpgqqflx4cnhwa3za": "gpt-oss-120b",
+    "bafkreicyuuvaeavozddtpc3tajfejaxuvuw2cpfajtt6lsddo22gcqg2km": "hermes-4",
     "bafkreiaha3sjfmv4affmi5kbu6bnayenf2avwafp3cthhar3latmfi632u": "flux-dev",
     "bafkreibks5pmc777snbo7dwk26sympe2o24tpqfedjq6gmgghwwu7iio34": "flux-schnell",
     "bafkreidbaksrogxispjejczfj36vtf5uzsbjt7irspl6kckynz5u2ugzke": "flux-dev-nsfw",
@@ -175,6 +176,12 @@ FEATURED_MODELS = {
         "hf-repo": "lmstudio-community/gpt-oss-20b-GGUF",
         "task": "chat",
         "backend": "mlx-lm"
+    },
+    "hermes-4": {
+        "repo": "bartowski/NousResearch_Hermes-4-70B-GGUF",
+        "model": "NousResearch_Hermes-4-70B-Q4_K_M.gguf",
+        "task": "chat",
+        "backend": "gguf"
     },
     "flux-dev": {
        "repo": "NikolaSigmoid/FLUX.1-dev",

--- a/eternal_zoo/models.py
+++ b/eternal_zoo/models.py
@@ -19,7 +19,7 @@ HASH_TO_MODEL = {
     "bafkreibokz6tdke7k3eozsro3hh3luyqbub7tzdawpswtt7q6bzfg36fw4": "dolphin-3.0-llama3.1-8b",
     "bafkreiclhnqcjfbbusqmg73jcwasomv7tqchkqm3fea5wwzs5vavc2wzfq": "gpt-oss-20b",
     "bafkreia4xtrb4vfsf7lblomjwh7cc3nlpci3fsqyeqpgqqflx4cnhwa3za": "gpt-oss-120b",
-    "bafkreicyuuvaeavozddtpc3tajfejaxuvuw2cpfajtt6lsddo22gcqg2km": "hermes-4",
+    "bafkreicyuuvaeavozddtpc3tajfejaxuvuw2cpfajtt6lsddo22gcqg2km": "hermes-4-70b",
     "bafkreiaha3sjfmv4affmi5kbu6bnayenf2avwafp3cthhar3latmfi632u": "flux-dev",
     "bafkreibks5pmc777snbo7dwk26sympe2o24tpqfedjq6gmgghwwu7iio34": "flux-schnell",
     "bafkreidbaksrogxispjejczfj36vtf5uzsbjt7irspl6kckynz5u2ugzke": "flux-dev-nsfw",
@@ -177,9 +177,15 @@ FEATURED_MODELS = {
         "task": "chat",
         "backend": "mlx-lm"
     },
-    "hermes-4": {
+    "hermes-4-70b": {
         "repo": "bartowski/NousResearch_Hermes-4-70B-GGUF",
         "model": "NousResearch_Hermes-4-70B-Q4_K_M.gguf",
+        "task": "chat",
+        "backend": "gguf"
+    },
+    "hermes-4-405b": {
+        "repo": "lmstudio-community/Hermes-4-405B-GGUF",
+        "pattern": "Q4_K_M",
         "task": "chat",
         "backend": "gguf"
     },


### PR DESCRIPTION
feat: Add Hermes-4 model support and fix embedding flags

## Summary
This PR adds support for Hermes-4 models (14B, 70B, and 405B variants) and fixes missing flag values for embedding functionality.

## Changes
- **Added Hermes-4 model support**: 
  - hermes-4-14b: 14B parameter model with GGUF backend
  - hermes-4-70b: 70B parameter model with GGUF backend  
  - hermes-4-405b: 405B parameter model with GGUF backend
- **Fixed embedding flags**: Added missing `-fa on` flag values in manager.py for proper embedding functionality
- **Updated model registry**: Added hash mapping for hermes-4-70b model